### PR TITLE
Add interactive card board components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# The-Card-Game-Simulator
+# The Card Game Simulator
+
+A lightweight React + Vite playground that demonstrates a draggable card table powered by Zustand, dnd-kit and framer-motion.
+
+## Getting started
+
+1. Install dependencies (internet access is required):
+   ```bash
+   npm install
+   ```
+2. Run the development playground:
+   ```bash
+   npm run dev
+   ```
+3. Open `http://localhost:5173` to interact with the example board. Double-click a card to flip it and drag it between the table and the hand zone.
+
+## Project structure
+
+- `src/state` – Zustand store and shared TypeScript models.
+- `src/lib/Table.ts` – snapping helpers used by the board.
+- `src/ui` – presentation components that wrap dnd-kit and framer-motion.
+- `src/examples/BoardExample.tsx` – demo data that seeds the store during development.
+
+The UI components are written in TypeScript with explicit props so they can be embedded in Storybook or any React host application.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "the-card-game-simulator",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@dnd-kit/core": "^6.0.8",
+    "@dnd-kit/modifiers": "^6.0.1",
+    "@dnd-kit/sortable": "^7.0.2",
+    "@dnd-kit/utilities": "^3.2.1",
+    "framer-motion": "^10.16.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.4",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>The Card Game Simulator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { Board } from './ui/Board';
+import { useGameStore } from './state/useGameStore';
+import { seedExampleState } from './examples/BoardExample';
+
+const App = () => {
+  const initialize = useGameStore((state) => state.actions.ensureExampleState);
+
+  useEffect(() => {
+    initialize(seedExampleState);
+  }, [initialize]);
+
+  return <Board />;
+};
+
+export default App;

--- a/src/examples/BoardExample.tsx
+++ b/src/examples/BoardExample.tsx
@@ -1,0 +1,98 @@
+import { useEffect } from 'react';
+import { Board } from '../ui/Board';
+import type { CardModel, ZoneModel } from '../state/types';
+import { useGameStore } from '../state/useGameStore';
+
+const CARD_WIDTH = 120;
+const CARD_HEIGHT = 168;
+
+export const seedExampleState = (): { zones: ZoneModel[]; cards: CardModel[] } => {
+  const tableZone: ZoneModel = {
+    id: 'zone-table',
+    name: 'Table',
+    type: 'board',
+    position: { x: 0, y: 0 },
+    size: { width: 1600, height: 900 },
+    cards: ['card-1', 'card-2']
+  };
+
+  const handZone: ZoneModel = {
+    id: 'zone-hand',
+    name: 'Player Hand',
+    type: 'hand',
+    position: { x: 80, y: 940 },
+    size: { width: 960, height: 220 },
+    cards: ['card-3', 'card-4', 'card-5']
+  };
+
+  const discardZone: ZoneModel = {
+    id: 'zone-discard',
+    name: 'Discard',
+    type: 'discard',
+    position: { x: 1320, y: 940 },
+    size: { width: 200, height: 220 },
+    cards: []
+  };
+
+  const cards: CardModel[] = [
+    {
+      id: 'card-1',
+      name: 'Arcane Burst',
+      description: 'Deal 3 damage to any target and draw a card.',
+      faceUp: true,
+      zoneId: tableZone.id,
+      position: { x: 220, y: 160 },
+      metadata: { cost: 2, attack: 3 }
+    },
+    {
+      id: 'card-2',
+      name: 'Stone Golem',
+      description: 'A sturdy defender summoned from the earth.',
+      faceUp: false,
+      zoneId: tableZone.id,
+      position: { x: 480, y: 360 },
+      metadata: { attack: 4, defense: 6 }
+    },
+    {
+      id: 'card-3',
+      name: 'Mystic Shield',
+      description: 'Prevent the next 3 damage to you.',
+      faceUp: true,
+      zoneId: handZone.id,
+      position: { x: 0, y: 0 }
+    },
+    {
+      id: 'card-4',
+      name: 'Thunder Strike',
+      description: 'Deal 4 damage to an enemy creature.',
+      faceUp: true,
+      zoneId: handZone.id,
+      position: { x: 0, y: 0 }
+    },
+    {
+      id: 'card-5',
+      name: 'Forest Guardian',
+      description: 'Summon a 2/2 creature token.',
+      faceUp: true,
+      zoneId: handZone.id,
+      position: { x: 0, y: 0 }
+    }
+  ];
+
+  return {
+    zones: [tableZone, handZone, discardZone],
+    cards
+  };
+};
+
+export const BoardExample = () => {
+  const initialize = useGameStore((state) => state.actions.ensureExampleState);
+
+  useEffect(() => {
+    initialize(seedExampleState);
+  }, [initialize]);
+
+  return <Board cardSize={{ width: CARD_WIDTH, height: CARD_HEIGHT }} />;
+};
+
+export default BoardExample;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,20 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #121212;
+  color: #f5f5f5;
+}
+
+body, html, #root {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+}
+
+body {
+  overflow: hidden;
+}
+
+button {
+  font: inherit;
+}

--- a/src/lib/Table.ts
+++ b/src/lib/Table.ts
@@ -1,0 +1,24 @@
+import type { Vector2 } from '../state/types';
+
+export interface SnapOptions {
+  gridSize?: number;
+}
+
+export const snap = (position: Vector2, options: SnapOptions = {}): Vector2 => {
+  const gridSize = options.gridSize ?? 40;
+  return {
+    x: Math.round(position.x / gridSize) * gridSize,
+    y: Math.round(position.y / gridSize) * gridSize
+  };
+};
+
+export const clampToZone = (
+  position: Vector2,
+  zoneSize: { width: number; height: number },
+  cardSize: { width: number; height: number }
+): Vector2 => {
+  return {
+    x: Math.min(Math.max(position.x, 0), Math.max(zoneSize.width - cardSize.width, 0)),
+    y: Math.min(Math.max(position.y, 0), Math.max(zoneSize.height - cardSize.height, 0))
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element #root not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -1,0 +1,58 @@
+export type Vector2 = {
+  x: number;
+  y: number;
+};
+
+export interface CardModel {
+  id: string;
+  name: string;
+  description?: string;
+  imageUrl?: string;
+  faceUp: boolean;
+  zoneId: string;
+  position: Vector2;
+  metadata?: Record<string, unknown>;
+}
+
+export type ZoneType = 'board' | 'hand' | 'discard' | 'deck';
+
+export interface ZoneModel {
+  id: string;
+  name: string;
+  type: ZoneType;
+  position: Vector2;
+  size: {
+    width: number;
+    height: number;
+  };
+  cards: string[];
+  accepts?: ZoneType[];
+  stacked?: boolean;
+  faceDown?: boolean;
+}
+
+export interface SnapPreview {
+  cardId: string;
+  zoneId: string;
+  position: Vector2;
+}
+
+export interface GameStoreState {
+  cards: Record<string, CardModel>;
+  zones: Record<string, ZoneModel>;
+  draggingCardId: string | null;
+  hoveringZoneId: string | null;
+  snapPreview: SnapPreview | null;
+  actions: GameStoreActions;
+}
+
+export interface GameStoreActions {
+  upsertZones: (zones: ZoneModel[]) => void;
+  upsertCards: (cards: CardModel[]) => void;
+  moveCard: (cardId: string, zoneId: string, position: Vector2) => void;
+  flipCard: (cardId: string) => void;
+  setDraggingCard: (cardId: string | null) => void;
+  setHoveringZone: (zoneId: string | null) => void;
+  setSnapPreview: (preview: SnapPreview | null) => void;
+  ensureExampleState: (seed: () => { zones: ZoneModel[]; cards: CardModel[] }) => void;
+}

--- a/src/state/useGameStore.ts
+++ b/src/state/useGameStore.ts
@@ -1,0 +1,149 @@
+import { create } from 'zustand';
+import type {
+  CardModel,
+  GameStoreActions,
+  GameStoreState,
+  SnapPreview,
+  Vector2,
+  ZoneModel
+} from './types';
+
+const buildRecord = <T extends { id: string }>(items: T[]): Record<string, T> =>
+  items.reduce<Record<string, T>>((acc, item) => {
+    acc[item.id] = item;
+    return acc;
+  }, {});
+
+export const useGameStore = create<GameStoreState>((set, get) => ({
+  cards: {},
+  zones: {},
+  draggingCardId: null,
+  hoveringZoneId: null,
+  snapPreview: null,
+  actions: {
+    upsertZones: (zones: ZoneModel[]) => {
+      set((state) => {
+        const updated = { ...state.zones };
+        zones.forEach((zone) => {
+          const existing = updated[zone.id];
+          updated[zone.id] = {
+            ...zone,
+            cards: zone.cards ?? existing?.cards ?? []
+          };
+        });
+        return { zones: updated };
+      });
+    },
+    upsertCards: (cards: CardModel[]) => {
+      set((state) => {
+        const zones = { ...state.zones };
+        const nextCards = { ...state.cards };
+        cards.forEach((card) => {
+          nextCards[card.id] = card;
+          const zone = zones[card.zoneId];
+          if (zone) {
+            if (!zone.cards.includes(card.id)) {
+              zones[card.zoneId] = {
+                ...zone,
+                cards: [...zone.cards, card.id]
+              };
+            }
+          } else {
+            zones[card.zoneId] = {
+              id: card.zoneId,
+              name: card.zoneId,
+              type: 'board',
+              position: { x: 0, y: 0 },
+              size: { width: 200, height: 280 },
+              cards: [card.id]
+            };
+          }
+        });
+        return { cards: nextCards, zones };
+      });
+    },
+    moveCard: (cardId: string, zoneId: string, position: Vector2) => {
+      set((state) => {
+        const card = state.cards[cardId];
+        if (!card) {
+          return state;
+        }
+
+        const updatedCards = {
+          ...state.cards,
+          [cardId]: {
+            ...card,
+            zoneId,
+            position
+          }
+        };
+
+        const zones = { ...state.zones };
+        const previousZone = zones[card.zoneId];
+        if (previousZone) {
+          zones[card.zoneId] = {
+            ...previousZone,
+            cards: previousZone.cards.filter((id) => id !== cardId)
+          };
+        }
+
+        const targetZone = zones[zoneId];
+        if (targetZone) {
+          zones[zoneId] = {
+            ...targetZone,
+            cards: targetZone.cards.includes(cardId)
+              ? targetZone.cards
+              : [...targetZone.cards, cardId]
+          };
+        }
+
+        return {
+          cards: updatedCards,
+          zones,
+          draggingCardId: null,
+          hoveringZoneId: null,
+          snapPreview: null
+        };
+      });
+    },
+    flipCard: (cardId: string) => {
+      set((state) => {
+        const card = state.cards[cardId];
+        if (!card) {
+          return state;
+        }
+        return {
+          cards: {
+            ...state.cards,
+            [cardId]: {
+              ...card,
+              faceUp: !card.faceUp
+            }
+          }
+        };
+      });
+    },
+    setDraggingCard: (cardId: string | null) => {
+      set({ draggingCardId: cardId });
+    },
+    setHoveringZone: (zoneId: string | null) => {
+      set({ hoveringZoneId: zoneId });
+    },
+    setSnapPreview: (preview: SnapPreview | null) => {
+      set({ snapPreview: preview });
+    },
+    ensureExampleState: (seed) => {
+      const { zones } = get();
+      if (Object.keys(zones).length > 0) {
+        return;
+      }
+      const { zones: seedZones, cards: seedCards } = seed();
+      set({
+        zones: buildRecord(seedZones),
+        cards: buildRecord(seedCards)
+      });
+    }
+  }
+}));
+
+export type UseGameStore = typeof useGameStore;

--- a/src/ui/Board.tsx
+++ b/src/ui/Board.tsx
@@ -1,0 +1,347 @@
+import {
+  DndContext,
+  DragCancelEvent,
+  DragEndEvent,
+  DragOverlay,
+  DragOverEvent,
+  DragStartEvent
+} from '@dnd-kit/core';
+import { motion } from 'framer-motion';
+import { useCallback, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { snap, clampToZone } from '../lib/Table';
+import { useGameStore } from '../state/useGameStore';
+import type { CardModel, Vector2, ZoneModel } from '../state/types';
+import { CardView, type CardSize } from './CardView';
+import { Hand } from './Hand';
+import { ZoneView } from './ZoneView';
+
+export interface BoardProps {
+  cardSize?: CardSize;
+  gridSize?: number;
+  background?: string;
+}
+
+const defaultBackground =
+  'radial-gradient(circle at 20% 20%, rgba(29, 43, 76, 0.65), transparent 60%), radial-gradient(circle at 80% 20%, rgba(111, 27, 97, 0.55), transparent 55%), radial-gradient(circle at 50% 80%, rgba(36, 110, 160, 0.45), transparent 50%)';
+
+export const Board = ({
+  cardSize = { width: 120, height: 168 },
+  gridSize = 40,
+  background = defaultBackground
+}: BoardProps) => {
+  const zones = useGameStore((state) => state.zones);
+  const cards = useGameStore((state) => state.cards);
+  const draggingCardId = useGameStore((state) => state.draggingCardId);
+  const snapPreview = useGameStore((state) => state.snapPreview);
+  const { setDraggingCard, setHoveringZone, setSnapPreview, moveCard, flipCard } = useGameStore(
+    (state) => state.actions
+  );
+
+  const [scale, setScale] = useState(1);
+  const [offset, setOffset] = useState<Vector2>({ x: 0, y: 0 });
+  const [isPanning, setIsPanning] = useState(false);
+  const lastPointerPosition = useRef<Vector2 | null>(null);
+
+  const zoneEntries = useMemo(() => Object.values(zones), [zones]);
+  const previewZone = snapPreview ? zones[snapPreview.zoneId] : undefined;
+
+  const draggingCard = draggingCardId ? cards[draggingCardId] : undefined;
+
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      const cardId = String(event.active.id);
+      setDraggingCard(cardId);
+    },
+    [setDraggingCard]
+  );
+
+  const handleDragOver = useCallback(
+    (event: DragOverEvent) => {
+      const cardId = String(event.active.id);
+      const overZoneId = event.over?.data.current?.zoneId as string | undefined;
+      setHoveringZone(overZoneId ?? null);
+
+      if (!overZoneId) {
+        setSnapPreview(null);
+        return;
+      }
+
+      const zone = zones[overZoneId];
+      const translatedRect = event.active.rect.current.translated;
+      const overRect = event.over?.rect;
+      if (!zone || !translatedRect || !overRect) {
+        setSnapPreview(null);
+        return;
+      }
+
+      const positionWithinZone = {
+        x: (translatedRect.left - overRect.left) / scale,
+        y: (translatedRect.top - overRect.top) / scale
+      };
+
+      const snapped = snap(positionWithinZone, { gridSize });
+      const clamped = clampToZone(snapped, zone.size, cardSize);
+
+      setSnapPreview({
+        cardId,
+        zoneId: overZoneId,
+        position: clamped
+      });
+    },
+    [cardSize, gridSize, scale, setHoveringZone, setSnapPreview, zones]
+  );
+
+  const handleDragCancel = useCallback(
+    (_event: DragCancelEvent) => {
+      setDraggingCard(null);
+      setHoveringZone(null);
+      setSnapPreview(null);
+    },
+    [setDraggingCard, setHoveringZone, setSnapPreview]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const cardId = String(event.active.id);
+      const overZoneId = event.over?.data.current?.zoneId as string | undefined;
+
+      if (!overZoneId) {
+        handleDragCancel(event);
+        return;
+      }
+
+      const zone = zones[overZoneId];
+      const translatedRect = event.active.rect.current.translated;
+      const overRect = event.over?.rect;
+
+      if (!zone || !translatedRect || !overRect) {
+        handleDragCancel(event);
+        return;
+      }
+
+      const positionWithinZone = {
+        x: (translatedRect.left - overRect.left) / scale,
+        y: (translatedRect.top - overRect.top) / scale
+      };
+
+      const snapped = snap(positionWithinZone, { gridSize });
+      const clamped = clampToZone(snapped, zone.size, cardSize);
+
+      moveCard(cardId, overZoneId, clamped);
+    },
+    [cardSize, gridSize, handleDragCancel, moveCard, scale, zones]
+  );
+
+  const handleWheel: React.WheelEventHandler<HTMLDivElement> = useCallback((event) => {
+    event.preventDefault();
+    const delta = event.deltaY > 0 ? -0.1 : 0.1;
+    setScale((previous) => {
+      const next = Math.min(Math.max(previous + delta, 0.6), 2.2);
+      return Number(next.toFixed(2));
+    });
+  }, []);
+
+  const handlePointerDown: React.PointerEventHandler<HTMLDivElement> = useCallback((event) => {
+    if (event.button === 1 || event.button === 2 || event.shiftKey) {
+      setIsPanning(true);
+      lastPointerPosition.current = { x: event.clientX, y: event.clientY };
+      event.currentTarget.setPointerCapture(event.pointerId);
+    }
+  }, []);
+
+  const handlePointerMove: React.PointerEventHandler<HTMLDivElement> = useCallback(
+    (event) => {
+      if (!isPanning || !lastPointerPosition.current) {
+        return;
+      }
+      const deltaX = event.clientX - lastPointerPosition.current.x;
+      const deltaY = event.clientY - lastPointerPosition.current.y;
+      setOffset((previous) => ({ x: previous.x + deltaX, y: previous.y + deltaY }));
+      lastPointerPosition.current = { x: event.clientX, y: event.clientY };
+    },
+    [isPanning]
+  );
+
+  const handlePointerUp: React.PointerEventHandler<HTMLDivElement> = useCallback((event) => {
+    if (isPanning) {
+      setIsPanning(false);
+      lastPointerPosition.current = null;
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  }, [isPanning]);
+
+  const boardContentStyle = useMemo<CSSProperties>(
+    () => ({
+      position: 'absolute',
+      inset: 0,
+      transform: `translate(${offset.x}px, ${offset.y}px) scale(${scale})`,
+      transformOrigin: '0 0',
+      background,
+      backgroundSize: 'cover',
+      borderRadius: 32,
+      boxShadow: '0 30px 70px rgba(0, 0, 0, 0.45)',
+      overflow: 'visible'
+    }),
+    [background, offset.x, offset.y, scale]
+  );
+
+  const boardGrid = useMemo<CSSProperties>(
+    () => ({
+      backgroundImage: `linear-gradient(transparent calc(${gridSize}px - 1px), rgba(255, 255, 255, 0.04) calc(${gridSize}px)), linear-gradient(90deg, transparent calc(${gridSize}px - 1px), rgba(255, 255, 255, 0.04) calc(${gridSize}px))`,
+      backgroundSize: `${gridSize}px ${gridSize}px`
+    }),
+    [gridSize]
+  );
+
+  const renderZone = useCallback(
+    (zone: ZoneModel) => {
+      const zoneCards = zone.cards
+        .map((id) => cards[id])
+        .filter((card): card is CardModel => Boolean(card));
+
+      if (zone.type === 'hand') {
+        return (
+          <Hand key={zone.id} zone={zone} cards={zoneCards} cardSize={cardSize} onFlipCard={flipCard} />
+        );
+      }
+
+      return (
+        <ZoneView
+          key={zone.id}
+          zone={zone}
+          cards={zoneCards}
+          cardSize={cardSize}
+          onFlipCard={flipCard}
+        />
+      );
+    },
+    [cardSize, cards, flipCard]
+  );
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        backgroundColor: '#05070c',
+        overflow: 'hidden'
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: 24,
+          left: 24,
+          zIndex: 20,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8
+        }}
+      >
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            type="button"
+            onClick={() => setScale((value) => Number(Math.min(value + 0.1, 2.2).toFixed(2)))}
+            style={controlButtonStyle}
+          >
+            +
+          </button>
+          <button
+            type="button"
+            onClick={() => setScale((value) => Number(Math.max(value - 0.1, 0.6).toFixed(2)))}
+            style={controlButtonStyle}
+          >
+            −
+          </button>
+          <button type="button" onClick={() => setScale(1)} style={controlButtonStyle}>
+            1:1
+          </button>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            type="button"
+            onClick={() => setOffset({ x: 0, y: 0 })}
+            style={controlButtonStyle}
+          >
+            Center
+          </button>
+        </div>
+      </div>
+      <DndContext
+        onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+      >
+        <motion.div
+          className="board-surface"
+          style={{
+            position: 'absolute',
+            inset: 32,
+            borderRadius: 32,
+            overflow: 'hidden',
+            cursor: isPanning ? 'grabbing' : 'default',
+            background: 'rgba(4,9,16,0.9)',
+            boxShadow: '0 40px 80px rgba(0,0,0,0.55)'
+          }}
+          onWheel={handleWheel}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerLeave={handlePointerUp}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              background: 'rgba(5, 11, 22, 0.7)'
+            }}
+          />
+          <motion.div className="board-content" style={{ ...boardContentStyle, ...boardGrid }}>
+            {snapPreview && previewZone ? (
+              <motion.div
+                layoutId="snap-preview"
+                style={{
+                  position: 'absolute',
+                  pointerEvents: 'none',
+                  left: previewZone.position.x + snapPreview.position.x,
+                  top: previewZone.position.y + snapPreview.position.y,
+                  width: cardSize.width,
+                  height: cardSize.height,
+                  borderRadius: 12,
+                  border: '2px solid rgba(90, 245, 198, 0.65)',
+                  background: 'rgba(90, 245, 198, 0.15)',
+                  boxShadow: '0 0 0 3px rgba(90, 245, 198, 0.15)'
+                }}
+              />
+            ) : null}
+            {zoneEntries.map((zone) => renderZone(zone))}
+          </motion.div>
+        </motion.div>
+        <DragOverlay adjustScale={false} dropAnimation={null}>
+          {draggingCard ? (
+            <CardView
+              card={draggingCard}
+              cardSize={cardSize}
+              overlay
+              draggable={false}
+              style={{ boxShadow: '0 16px 40px rgba(0,0,0,0.5)' }}
+            />
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+    </div>
+  );
+};
+
+const controlButtonStyle: CSSProperties = {
+  background: 'rgba(17, 23, 36, 0.85)',
+  border: '1px solid rgba(255, 255, 255, 0.08)',
+  borderRadius: 8,
+  color: '#f5f7fa',
+  padding: '6px 12px',
+  cursor: 'pointer'
+};
+
+export default Board;

--- a/src/ui/CardView.tsx
+++ b/src/ui/CardView.tsx
@@ -1,0 +1,149 @@
+import { useMemo } from 'react';
+import { useDraggable } from '@dnd-kit/core';
+import { motion } from 'framer-motion';
+import type { CSSProperties } from 'react';
+import type { CardModel } from '../state/types';
+
+export interface CardSize {
+  width: number;
+  height: number;
+}
+
+export interface CardViewProps {
+  card: CardModel;
+  cardSize: CardSize;
+  draggable?: boolean;
+  overlay?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  onFlip?: (cardId: string) => void;
+}
+
+const cardShadow = '0 10px 30px rgba(0, 0, 0, 0.35)';
+
+export const CardView = ({
+  card,
+  cardSize,
+  draggable = true,
+  overlay = false,
+  className,
+  style,
+  onFlip
+}: CardViewProps) => {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: card.id,
+    disabled: !draggable || overlay,
+    data: {
+      type: 'card',
+      cardId: card.id,
+      zoneId: card.zoneId
+    }
+  });
+
+  const dragStyle = useMemo(() => {
+    if (!transform) {
+      return undefined;
+    }
+    const { x, y } = transform;
+    return {
+      transform: `translate3d(${x}px, ${y}px, 0)`
+    } satisfies CSSProperties;
+  }, [transform]);
+
+  const mergedStyle: CSSProperties = {
+    width: cardSize.width,
+    height: cardSize.height,
+    borderRadius: 12,
+    position: 'relative',
+    transformStyle: 'preserve-3d',
+    cursor: draggable ? (isDragging ? 'grabbing' : 'grab') : 'default',
+    boxShadow: card.faceUp ? cardShadow : 'none',
+    ...style,
+    ...(dragStyle ?? {})
+  };
+
+  return (
+    <motion.div
+      ref={setNodeRef}
+      className={className}
+      layout
+      layoutId={card.id}
+      style={mergedStyle}
+      onDoubleClick={() => onFlip?.(card.id)}
+      {...listeners}
+      {...attributes}
+    >
+      <motion.div
+        className="card-inner"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          borderRadius: 12,
+          overflow: 'hidden',
+          transformStyle: 'preserve-3d',
+          background: card.faceUp
+            ? 'linear-gradient(135deg, rgba(35, 31, 64, 0.95), rgba(119, 42, 126, 0.95))'
+            : 'linear-gradient(135deg, rgba(24, 28, 33, 0.95), rgba(55, 59, 68, 0.95))'
+        }}
+        animate={{ rotateY: card.faceUp ? 0 : 180 }}
+        initial={false}
+        transition={{ type: 'spring', stiffness: 260, damping: 20 }}
+      >
+        <motion.div
+          className="card-face card-face--front"
+          style={{
+            position: 'absolute',
+            inset: 0,
+            padding: '12px 14px',
+            backfaceVisibility: 'hidden',
+            color: '#fdfdff',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between'
+          }}
+        >
+          <div style={{ fontSize: 14, fontWeight: 700, letterSpacing: 0.4 }}>{card.name}</div>
+          <div style={{ fontSize: 12, lineHeight: 1.4, opacity: 0.9 }}>{card.description}</div>
+          {card.metadata ? (
+            <div
+              style={{
+                display: 'flex',
+                gap: 8,
+                fontSize: 11,
+                opacity: 0.85,
+                flexWrap: 'wrap'
+              }}
+            >
+              {Object.entries(card.metadata).map(([key, value]) => (
+                <span key={key}>
+                  {key}: {String(value)}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </motion.div>
+        <motion.div
+          className="card-face card-face--back"
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backfaceVisibility: 'hidden',
+            transform: 'rotateY(180deg)',
+            fontSize: 18,
+            fontWeight: 600,
+            letterSpacing: 1,
+            color: '#f0f0f0',
+            background: 'linear-gradient(135deg, rgba(17, 84, 173, 0.9), rgba(17, 132, 179, 0.9))'
+          }}
+        >
+          {card.name}
+        </motion.div>
+      </motion.div>
+    </motion.div>
+  );
+};
+
+export default CardView;

--- a/src/ui/Hand.tsx
+++ b/src/ui/Hand.tsx
@@ -1,0 +1,91 @@
+import { useDroppable } from '@dnd-kit/core';
+import { motion } from 'framer-motion';
+import type { CardModel, ZoneModel } from '../state/types';
+import { CardView, type CardSize } from './CardView';
+
+export interface HandProps {
+  zone: ZoneModel;
+  cards: CardModel[];
+  cardSize: CardSize;
+  onFlipCard: (cardId: string) => void;
+}
+
+export const Hand = ({ zone, cards, cardSize, onFlipCard }: HandProps) => {
+  const { setNodeRef, isOver } = useDroppable({
+    id: zone.id,
+    data: {
+      type: 'zone',
+      zoneId: zone.id
+    }
+  });
+
+  const spread = Math.min(18, Math.max(8, 32 - cards.length));
+  const fanOrigin = (cards.length - 1) / 2;
+
+  return (
+    <motion.div
+      ref={setNodeRef}
+      layout
+      className="hand-zone"
+      style={{
+        position: 'absolute',
+        left: zone.position.x,
+        top: zone.position.y,
+        width: zone.size.width,
+        height: zone.size.height,
+        borderRadius: 24,
+        border: `2px dashed ${isOver ? '#5af5c6' : 'rgba(255,255,255,0.08)'}`,
+        background: 'linear-gradient(180deg, rgba(17, 28, 41, 0.85), rgba(10, 15, 24, 0.9))',
+        boxShadow: isOver ? '0 0 0 4px rgba(90, 245, 198, 0.35)' : '0 8px 20px rgba(0,0,0,0.35)',
+        padding: '48px 24px 24px',
+        display: 'flex',
+        alignItems: 'flex-end',
+        justifyContent: 'center',
+        overflow: 'visible'
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: 16,
+          left: 28,
+          fontSize: 14,
+          fontWeight: 600,
+          letterSpacing: 0.5,
+          textTransform: 'uppercase',
+          opacity: 0.8
+        }}
+      >
+        {zone.name}
+      </div>
+      {cards.map((card, index) => {
+        const offset = index - fanOrigin;
+        const rotation = offset * (spread * 0.35);
+        const translateX = offset * (cardSize.width * 0.45);
+        const translateY = Math.abs(offset) * -10;
+        return (
+          <motion.div
+            key={card.id}
+            layout
+            style={{
+              position: 'relative',
+              transform: `translateX(${translateX}px) translateY(${translateY}px) rotate(${rotation}deg)`,
+              transformOrigin: 'bottom center',
+              zIndex: index,
+              margin: '0 -32px'
+            }}
+          >
+            <CardView
+              card={card}
+              cardSize={cardSize}
+              style={{}}
+              onFlip={onFlipCard}
+            />
+          </motion.div>
+        );
+      })}
+    </motion.div>
+  );
+};
+
+export default Hand;

--- a/src/ui/ZoneView.tsx
+++ b/src/ui/ZoneView.tsx
@@ -1,0 +1,87 @@
+import { useDroppable } from '@dnd-kit/core';
+import { motion } from 'framer-motion';
+import type { CardModel, ZoneModel } from '../state/types';
+import { CardView, type CardSize } from './CardView';
+
+export interface ZoneViewProps {
+  zone: ZoneModel;
+  cards: CardModel[];
+  cardSize: CardSize;
+  onFlipCard: (cardId: string) => void;
+}
+
+export const ZoneView = ({ zone, cards, cardSize, onFlipCard }: ZoneViewProps) => {
+  const { isOver, setNodeRef } = useDroppable({
+    id: zone.id,
+    data: {
+      type: 'zone',
+      zoneId: zone.id
+    }
+  });
+
+  const stacked = zone.stacked ?? false;
+
+  return (
+    <motion.div
+      ref={setNodeRef}
+      layout
+      className="zone-view"
+      style={{
+        position: 'absolute',
+        left: zone.position.x,
+        top: zone.position.y,
+        width: zone.size.width,
+        height: zone.size.height,
+        borderRadius: 16,
+        border: `2px dashed ${isOver ? '#4dd5ff' : 'rgba(255,255,255,0.1)'}`,
+        background: 'rgba(18, 21, 28, 0.6)',
+        boxShadow: isOver ? '0 0 0 4px rgba(77, 213, 255, 0.35)' : '0 8px 30px rgba(0, 0, 0, 0.2)',
+        transition: 'box-shadow 0.2s ease, border 0.2s ease',
+        overflow: 'hidden'
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: 12,
+          left: 16,
+          fontSize: 14,
+          fontWeight: 600,
+          letterSpacing: 0.6,
+          textTransform: 'uppercase',
+          opacity: 0.8
+        }}
+      >
+        {zone.name}
+      </div>
+      <div style={{ position: 'absolute', inset: 0 }}>
+        {cards.map((card, index) => {
+          const positionStyle = stacked
+            ? {
+                left: 20 + index * 3,
+                top: 40 + index * 3
+              }
+            : {
+                left: card.position.x,
+                top: card.position.y
+              };
+
+          return (
+            <CardView
+              key={card.id}
+              card={card}
+              cardSize={cardSize}
+              style={{
+                position: 'absolute',
+                ...positionStyle
+              }}
+              onFlip={onFlipCard}
+            />
+          );
+        })}
+      </div>
+    </motion.div>
+  );
+};
+
+export default ZoneView;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React workspace with TypeScript configuration for the simulator UI
- implement Board, ZoneView, Hand, and CardView components with dnd-kit drag/drop and framer-motion animations backed by a Zustand store
- add an example page that seeds demo data and documents usage in the README

## Testing
- not run (npm install is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e65c0a7fc0832c9d533c718e6b74f7